### PR TITLE
add support for auto refresh (ask FordPass servers to refresh car info)

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -29,18 +29,32 @@
             "title": "VIN",
             "type": "string",
             "required": true
-          },
-          "autoRefresh": {
-            "title": "Auto-refresh",
-            "type": "boolean",
-            "required": true
-          },
-          "refreshRate": {
-            "title": "Refresh rate (in minutes)",
-            "type": "number",
-            "required": false
           }
         }
+      }
+    },
+    "options": {
+      "title": "Advanced Settings",
+      "expandable": true,
+      "type": "object",
+      "properties": {
+        "autoRefresh": {
+          "title": "Auto-refresh",
+          "description": "Note: This will use your vehicle's battery to refresh data.",
+          "type": "boolean",
+          "default": false
+        },
+        "refreshRate": {
+          "title": "Refresh rate (in minutes)",
+          "description": "Note: Faster refresh times will significantly drain your vehicle's battery.",
+          "type": "integer",
+          "default": 180,
+          "minimum": 60,
+          "maximum": 720,
+          "condition": {
+            "functionBody": "return model.options.autoRefresh === true;"
+          }          
+        }        
       }
     }
   }

--- a/config.schema.json
+++ b/config.schema.json
@@ -29,6 +29,16 @@
             "title": "VIN",
             "type": "string",
             "required": true
+          },
+          "autoRefresh": {
+            "title": "Auto-refresh",
+            "type": "boolean",
+            "required": true
+          },
+          "refreshRate": {
+            "title": "Refresh rate (in minutes)",
+            "type": "number",
+            "required": false
           }
         }
       }

--- a/src/fordpass.ts
+++ b/src/fordpass.ts
@@ -22,12 +22,16 @@ export class Vehicle {
   private lastUpdatedTime: Date;
   name: string;
   vin: string;
+  autoRefresh: boolean;
+  refreshRate: number;
 
-  constructor(name: string, vin: string, config: PlatformConfig, log: Logging) {
+  constructor(name: string, vin: string, autoRefresh: boolean, refreshRate: number, config: PlatformConfig, log: Logging) {
     this.config = config;
     this.log = log;
     this.name = name;
     this.vin = vin;
+    this.autoRefresh = autoRefresh;
+    this.refreshRate = refreshRate;
     this.lastUpdatedTime = new Date();
   }
 
@@ -89,6 +93,11 @@ export class Vehicle {
         endpoint = `api/vehicles/v2/${this.vin}/doors/lock`;
         break;
       }
+      case Command.REFRESH: {
+        method = 'PUT';
+        endpoint = `api/vehicles/v2/${this.vin}/status`;
+        break;
+      }
       default: {
         this.log.error('invalid command');
         break;
@@ -121,6 +130,8 @@ export class Vehicle {
       endpoint = `api/vehicles/v2/${this.vin}/engine/start/${commandId}`;
     } else if (command === Command.LOCK || command === Command.UNLOCK) {
       endpoint = `api/vehicles/v2/${this.vin}/doors/lock/${commandId}`;
+    } else if (command === Command.REFRESH) {
+      endpoint = `api/vehicles/v2/${this.vin}/status/${commandId}`;
     } else {
       this.log.error('invalid command');
     }

--- a/src/fordpass.ts
+++ b/src/fordpass.ts
@@ -1,8 +1,9 @@
 import axios from 'axios';
 import { AxiosRequestConfig, Method } from 'axios';
-import { PlatformConfig, Logging } from 'homebridge';
+import { Logging } from 'homebridge';
 import { VehicleInfo, Command } from './models/vehicle';
 import { CommandStatus } from './models/command';
+import { FordpassConfig } from './models/config';
 
 const defaultHeaders = {
   'Content-Type': 'application/json',
@@ -16,7 +17,7 @@ const handleError = function (name: string, status: number, log: Logging): void 
 };
 
 export class Vehicle {
-  private config: PlatformConfig;
+  private config: FordpassConfig;
   private readonly log: Logging;
   private info: VehicleInfo | undefined;
   private lastUpdatedTime: Date;
@@ -25,13 +26,13 @@ export class Vehicle {
   autoRefresh: boolean;
   refreshRate: number;
 
-  constructor(name: string, vin: string, autoRefresh: boolean, refreshRate: number, config: PlatformConfig, log: Logging) {
+  constructor(name: string, vin: string, config: FordpassConfig, log: Logging) {
     this.config = config;
     this.log = log;
     this.name = name;
     this.vin = vin;
-    this.autoRefresh = autoRefresh;
-    this.refreshRate = refreshRate;
+    this.autoRefresh = config.options?.autoRefresh || false;
+    this.refreshRate = config.options?.refreshRate || 180;
     this.lastUpdatedTime = new Date();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,14 +58,7 @@ class FordPassPlatform implements DynamicPlatformPlugin {
       this.log.info(`${accessory.displayName} identified!`);
     });
 
-    const vehicle = new Vehicle(
-        accessory.context.name,
-        accessory.context.vin,
-        accessory.context.autoRefresh,
-        accessory.context.refreshRate,
-        this.config,
-        this.log
-    );
+    const vehicle = new Vehicle(accessory.context.name, accessory.context.vin, this.config, this.log);
     const fordAccessory = new FordpassAccessory(accessory);
 
     // Create Lock service
@@ -201,8 +194,6 @@ class FordPassPlatform implements DynamicPlatformPlugin {
       const accessory = new Accessory(vehicle.name, uuid);
       accessory.context.name = vehicle.name;
       accessory.context.vin = vehicle.vin;
-      accessory.context.autoRefresh = vehicle.autoRefresh;
-      accessory.context.refreshRate = vehicle.refreshRate;
 
       const accessoryInformation = accessory.getService(hap.Service.AccessoryInformation);
       if (accessoryInformation) {
@@ -267,7 +258,7 @@ class FordPassPlatform implements DynamicPlatformPlugin {
         this.log.debug(`Configuring ${vehicle.name} to refresh every ${vehicle.refreshRate} minutes.`);
         setInterval(async () => {
           this.log.debug(`Refreshing info for ${vehicle.name}`);
-          await vehicle.issueCommand(Command.REFRESH)
+          await vehicle.issueCommand(Command.REFRESH);
         }, 60000 * vehicle.refreshRate);
       }
     });

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -1,14 +1,18 @@
 import { PlatformConfig } from 'homebridge';
 
+interface Options {
+  autoRefresh?: boolean;
+  refreshRate?: number;
+}
+
 export interface VehicleConfig {
   name: string;
   vin: string;
-  autoRefresh: boolean;
-  refreshRate: number;
 }
 
 export interface FordpassConfig extends PlatformConfig {
   username?: string;
   password?: string;
   vehicles?: Array<VehicleConfig>;
+  options?: Options;
 }

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -3,6 +3,8 @@ import { PlatformConfig } from 'homebridge';
 export interface VehicleConfig {
   name: string;
   vin: string;
+  autoRefresh: boolean;
+  refreshRate: number;
 }
 
 export interface FordpassConfig extends PlatformConfig {

--- a/src/models/vehicle.ts
+++ b/src/models/vehicle.ts
@@ -46,6 +46,7 @@ export enum Command {
   UNLOCK = 'unlock',
   START = 'start',
   STOP = 'stop',
+  REFRESH = 'refresh',
 }
 
 export interface VehicleInfo {


### PR DESCRIPTION
There is an endpoint to ask FordPass servers to refresh car info.
When querying /status with GET method, we only retrieve cached info. Querying /status with PUT method will ask for a refresh.
It must be used with caution because this request uses car's battery.